### PR TITLE
change (Dockerfile): new CI image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
   dev:
     container_name: node-template
-    image: parity/rust-builder:latest
+    image: paritytech/ci-linux:production
     working_dir: /var/www/node-template
     ports:
       - "9944:9944"


### PR DESCRIPTION
Please consider changing the source image as `parity/rust-builder` is going to be deprecated.